### PR TITLE
Avoid using scientific notation

### DIFF
--- a/create_regions_from_gencode.R
+++ b/create_regions_from_gencode.R
@@ -7,6 +7,9 @@ suppressMessages(library(GenomicFeatures))
 suppressMessages(library(dplyr))
 gencode_gff <- args[1]
 output_dir <- args[2]
+
+options(scipen=999)
+
 Mode <- function(x) {
   ux <- unique(x)
   ux[which.max(tabulate(match(x, ux)))]


### PR DESCRIPTION
With default scipen=0, resulting bed files may contain "1.27e+08" instead of "127000000" (example in GRCm38/vM14/promoters.3000.bed.gz), which by some downstream bed tools will be read as 1.